### PR TITLE
CI: Add CI/CD Workflows for `Release Drafter` and `Checkout Instructions`

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -1,0 +1,15 @@
+# CI/CD Workflows Documentation
+
+This repository contains the following GitHub Actions workflows:
+
+## 1. CI: Release Drafter
+
+- **Purpose**: Automatically creates draft release notes based on merged pull requests and commits.
+- **Trigger**: Scheduled to run daily at midnight.
+- **Permissions**: Requires write access to the repository and pull requests.
+
+## 2. CI: Checkout Instructions Creator
+
+- **Purpose**: Comments checkout instructions on newly opened pull requests against the main branch.
+- **Trigger**: On opening a pull request against the main branch.
+- **Permissions**: Requires write access to comment on pull requests.

--- a/.github/release-config.yml
+++ b/.github/release-config.yml
@@ -1,0 +1,87 @@
+version-template: "$MAJOR"
+tag-template: "sprint-$NEXT_MAJOR_VERSION-release"
+commitish: "main"
+
+name-template: "Sprint $NEXT_MAJOR_VERSION Release"
+category-template: "### $TITLE"
+change-template: "- $TITLE (#$NUMBER) by @$AUTHOR"
+
+exclude-labels:
+  - "release: ignore"
+
+categories:
+  - title: "🚀 New Features"
+    labels:
+      - "release: feature"
+  - title: "🐛 Bug Fixes"
+    labels:
+      - "release: bug-fix"
+  - title: "📚 Documentation Updates"
+    labels:
+      - "release: documentation"
+  - title: "🔄 CI/CD Improvements"
+    labels:
+      - "release: ci-cd"
+  - title: "🛠️ Code Refactoring"
+    labels:
+      - "release: refactor"
+  - title: "⚡ Performance Improvements"
+    labels:
+      - "release: performance"
+  - title: "🔬 Tests"
+    labels:
+      - "release: test"
+  - title: "🧱 Build System"
+    labels:
+      - "release: build"
+  - title: "🎨 Style Changes"
+    labels:
+      - "release: style"
+  - title: "🔧 Chores"
+    labels:
+      - "release: chore"
+
+autolabeler:
+  - label: "release: feature"
+    title:
+      - '/^feat/i'
+  - label: "release: bug-fix"
+    title: 
+      - '/^fix/i'
+  - label: "release: documentation"
+    title:
+      - '/^docs/i'
+    files:
+      - '*.md'
+      - '*.txt'
+  - label: "release: ci-cd"
+    title: 
+      - '/^ci/i'
+  - label: "release: refactor"
+    title:
+      - '/^refactor/i'
+  - label: "release: performance"
+    title:
+      - '/^perf/i'
+  - label: "release: test"
+    title:
+      - '/^test/i'
+  - label: "release: build"
+    title:
+      - '/^build/i'
+  - label: "release: style"
+    title:
+      - '/^style/i'
+  - label: "release: chore"
+    title:
+      - '/^chore/i'
+
+template: |
+  ## 🚀 Sprint Release $NEXT_MAJOR_VERSION:
+    
+  $CHANGES
+
+
+  ## 👥 Contributors:
+    
+  $CONTRIBUTORS

--- a/.github/workflows/checkout-instruction-creator.yml
+++ b/.github/workflows/checkout-instruction-creator.yml
@@ -1,0 +1,50 @@
+# CI Workflow: Checkout Instructions Creator
+#
+# This workflow automatically adds a comment with checkout instructions on newly opened 
+# pull requests (PRs) targeting the main branch.
+# The comment provides easy-to-follow steps for checking out the PR branch locally.
+
+name: "CI: Checkout Instructions Creator"
+
+# This workflow is triggered when a pull request is opened against the main branch
+on:
+  pull_request:
+    branches:
+      - main
+    types:
+      - opened
+
+# This workflow requires write permissions to create comments on pull requests
+permissions:
+  id-token: write
+  contents: write
+  pull-requests: write
+
+jobs:
+  # Job to post checkout instructions as a comment on a newly opened pull request
+  pr-commenter:
+    runs-on: ubuntu-latest
+    name: Comment on PR
+
+    steps:
+      # Step to check out the repository (required by the GitHub Action)
+      - name: Checkout
+        uses: actions/checkout@v4
+      
+      # Step to comment on the pull request with checkout instructions
+      - name: Comment PR
+        uses: thollander/actions-comment-pull-request@v3
+        with:
+          # GitHub token required to authenticate and post the comment
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          # Message containing the checkout instructions
+          message: |
+            👋 Hi there!
+          
+            ### 🚀 Checkout Instructions
+            ```bash
+            git fetch origin
+            git checkout ${{ github.head_ref }}
+            ```
+
+            Happy coding! 🎉

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,39 @@
+# CI Workflow: Release Drafter
+#
+# This workflow automates the process of drafting release notes for the project. It is triggered
+# daily at midnight using a cron schedule.
+#
+# Jobs:
+# 1. **release-drafter**: This job generates a draft release based on the commits and PRs merged
+#    into the main branch. It uses the `release-config.yml` file to categorize and format the release notes.
+
+name: "CI: Release Drafter"
+
+# This workflow is triggered daily at midnight (00:00 UTC)
+on:
+  schedule:
+    - cron: '0 0 * * *'
+
+# This workflow requires write permissions to create releases and manage pull requests
+permissions:
+  id-token: write
+  contents: write
+  pull-requests: write
+
+jobs:
+  # Job to create a draft release
+  release-drafter:
+    runs-on: ubuntu-latest
+    steps:
+      # Step to run the Release Drafter action
+      - name: Release Drafter
+        uses: release-drafter/release-drafter@v6
+        with:
+          # The config file that defines how the release draft is generated
+          config-name: release-config.yml
+          # Enable autolabeler to automatically categorize commits based on their types
+          disable-autolabeler: false
+          publish: false
+        env:
+          # GitHub token required to authenticate and perform actions (like creating releases)
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -13,6 +13,11 @@ name: "CI: Release Drafter"
 on:
   schedule:
     - cron: '0 0 * * *'
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
 
 # This workflow requires write permissions to create releases and manage pull requests
 permissions:


### PR DESCRIPTION
**Note:**

The Release Drafter workflow is currently not working because it requires a config file in the default branch, but since we just created a PR, it should not fail from the next PR.